### PR TITLE
feat: add rate limiting middleware and RateLimit entity with migration

### DIFF
--- a/src/entity/RateLimit.ts
+++ b/src/entity/RateLimit.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryColumn, Column, UpdateDateColumn } from "typeorm";
+
+@Entity("rate_limits")
+export class RateLimit {
+  @PrimaryColumn({ length: 45 })
+  ip_address!: string;
+
+  @Column({ default: 1 })
+  request_count!: number;
+
+  @UpdateDateColumn()
+  last_request_time!: Date;
+}

--- a/src/middleware/rateLimitMiddleware.ts
+++ b/src/middleware/rateLimitMiddleware.ts
@@ -1,0 +1,57 @@
+import { Request, Response, NextFunction } from "express";
+import { AppDataSource } from "../config/database";
+import { RateLimit } from "../entity/RateLimit";
+
+const rateLimitRepository = AppDataSource.getRepository(RateLimit);
+
+const MAX_REQUESTS = 100;
+const WINDOW_SIZE_IN_SECONDS = 60;
+
+export const rateLimitMiddleware = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const clientIdentifier = req.ip;
+
+  if (!clientIdentifier) {
+    res.status(500).json({ error: "Could not identify the client." });
+    return;
+  }
+
+  try {
+    let rateLimit = await rateLimitRepository.findOneBy({
+      ip_address: clientIdentifier,
+    });
+    const currentTime = new Date();
+
+    if (rateLimit) {
+      const timeDiffSeconds =
+        (currentTime.getTime() - rateLimit.last_request_time.getTime()) / 1000;
+
+      if (timeDiffSeconds < WINDOW_SIZE_IN_SECONDS) {
+        if (rateLimit.request_count >= MAX_REQUESTS) {
+          res
+            .status(429)
+            .json({ error: "Too Many Requests. Please try again later." });
+          return;
+        }
+        rateLimit.request_count++;
+      } else {
+        rateLimit.request_count = 1;
+      }
+      await rateLimitRepository.save(rateLimit);
+    } else {
+      rateLimit = rateLimitRepository.create({
+        ip_address: clientIdentifier,
+        request_count: 1,
+      });
+      await rateLimitRepository.save(rateLimit);
+    }
+
+    next();
+  } catch (error) {
+    console.error("Error in rate limit middleware:", error);
+    next();
+  }
+};

--- a/src/migration/1750440472682-AddRateLimitTable.ts
+++ b/src/migration/1750440472682-AddRateLimitTable.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class AddRateLimitTable1750440472682 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "rate_limits",
+        columns: [
+          {
+            name: "ip_address",
+            type: "varchar",
+            length: "45",
+            isPrimary: true,
+          },
+          {
+            name: "request_count",
+            type: "int",
+            default: 1,
+          },
+          {
+            name: "last_request_time",
+            type: "timestamp",
+            default: "CURRENT_TIMESTAMP",
+            onUpdate: "CURRENT_TIMESTAMP",
+          },
+        ],
+      }),
+      true
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("rate_limits");
+  }
+}

--- a/src/routes/translationRoutes.ts
+++ b/src/routes/translationRoutes.ts
@@ -5,10 +5,16 @@ import {
   getTranslationById,
 } from "../controllers/translationController";
 import { authMiddleware } from "../middleware/authMiddleware";
+import { rateLimitMiddleware } from "../middleware/rateLimitMiddleware";
 
 const router = Router();
 
-router.post("/translate", authMiddleware, handleTranslationRequest);
+router.post(
+  "/translate",
+  authMiddleware,
+  rateLimitMiddleware,
+  handleTranslationRequest
+);
 router.get("/translations", authMiddleware, getTranslationHistory);
 router.get("/translations/:id", authMiddleware, getTranslationById);
 


### PR DESCRIPTION
This pull request introduces a rate-limiting feature to the application to prevent excessive requests from individual clients. The implementation includes creating a database table to track request counts, middleware to enforce rate limits, and integration of the middleware into the translation routes.

### Rate-Limiting Feature

**Entity and Database Changes:**
* Added a new `RateLimit` entity in `src/entity/RateLimit.ts` to represent rate-limiting data, including `ip_address`, `request_count`, and `last_request_time`.
* Created a migration file `1750440472682-AddRateLimitTable.ts` to add the `rate_limits` table to the database, with columns for IP address, request count, and last request time.

**Middleware for Rate Limiting:**
* Implemented `rateLimitMiddleware` in `src/middleware/rateLimitMiddleware.ts` to enforce a maximum of 100 requests per IP address within a 60-second window. The middleware checks and updates the database for each request.

**Integration with Routes:**
* Updated `src/routes/translationRoutes.ts` to include `rateLimitMiddleware` in the `/translate` route, ensuring rate limits are applied to this endpoint.