### PR TITLE
feat: add supported languages functionality with seeding, validation and retrieval endpoints

### DIFF
--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -14,7 +14,7 @@ export const AppDataSource = new DataSource({
   database: process.env.DB_NAME,
   synchronize: false,
   logging: false,
-  entities: [path.join(__dirname, "../entity/**/*.js")],
-  migrations: [path.join(__dirname, "../migration/**/*.js")],
+  entities: [path.join(__dirname, "../entity/**/*.{js,ts}")],
+  migrations: [path.join(__dirname, "../migration/**/*.{js,ts}")],
   subscribers: [],
 });

--- a/src/entity/SupportedLanguage.ts
+++ b/src/entity/SupportedLanguage.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryColumn, Column } from "typeorm";
+
+@Entity("supported_languages")
+export class SupportedLanguage {
+  @PrimaryColumn({ length: 10 })
+  language_code!: string;
+
+  @Column({ length: 255 })
+  language_name!: string;
+}

--- a/src/migration/1750440472682-AddSupportedLanguagesTable.ts
+++ b/src/migration/1750440472682-AddSupportedLanguagesTable.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class AddSupportedLanguagesTable1750440472682
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "supported_languages",
+        columns: [
+          {
+            name: "language_code",
+            type: "varchar",
+            length: "10",
+            isPrimary: true,
+          },
+          {
+            name: "language_name",
+            type: "varchar",
+            length: "255",
+          },
+        ],
+      }),
+      true
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("supported_languages");
+  }
+}

--- a/src/routes/translationRoutes.ts
+++ b/src/routes/translationRoutes.ts
@@ -3,6 +3,7 @@ import {
   handleTranslationRequest,
   getTranslationHistory,
   getTranslationById,
+  getLanguages,
 } from "../controllers/translationController";
 import { authMiddleware } from "../middleware/authMiddleware";
 import { rateLimitMiddleware } from "../middleware/rateLimitMiddleware";
@@ -17,5 +18,6 @@ router.post(
 );
 router.get("/translations", authMiddleware, getTranslationHistory);
 router.get("/translations/:id", authMiddleware, getTranslationById);
+router.get("/languages", getLanguages);
 
 export default router;

--- a/src/seeder/seed.ts
+++ b/src/seeder/seed.ts
@@ -1,0 +1,40 @@
+import { AppDataSource } from "../config/database";
+import { SupportedLanguage } from "../entity/SupportedLanguage";
+
+const seedLanguages = async () => {
+  console.log("Initializing data source for seeding...");
+  await AppDataSource.initialize();
+  console.log("Data source initialized. Seeding languages...");
+  const langRepository = AppDataSource.getRepository(SupportedLanguage);
+
+  const languages = [
+    { language_code: "de", language_name: "German" },
+    { language_code: "en", language_name: "English" },
+    { language_code: "en-GB", language_name: "English (British)" },
+    { language_code: "en-US", language_name: "English (American)" },
+    { language_code: "es", language_name: "Spanish" },
+    { language_code: "fr", language_name: "French" },
+    { language_code: "pt", language_name: "Portuguese" },
+    { language_code: "pt-BR", language_name: "Portuguese (Brazilian)" },
+    { language_code: "pt-PT", language_name: "Portuguese (European)" },
+  ];
+
+  for (const lang of languages) {
+    const existing = await langRepository.findOne({
+      where: { language_code: lang.language_code },
+    });
+    if (!existing) {
+      await langRepository.save(langRepository.create(lang));
+      console.log(
+        `Added language: ${lang.language_name} (${lang.language_code})`
+      );
+    }
+  }
+  await AppDataSource.destroy();
+  console.log("Language seeding complete.");
+};
+
+seedLanguages().catch((error) => {
+  console.error("Error seeding languages:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request introduces support for managing and validating supported languages in the translation service. It includes database schema updates, new API endpoints, and a seeder script for initializing supported languages.

### Database and Entity Updates:
* Updated the database configuration to support both `.js` and `.ts` files for entities and migrations (`src/config/database.ts`).
* Added a new `SupportedLanguage` entity to represent supported languages in the database (`src/entity/SupportedLanguage.ts`).
* Created a migration to add the `supported_languages` table with `language_code` and `language_name` columns (`src/migration/1750440472682-AddSupportedLanguagesTable.ts`).

### API Enhancements:
* Added validation in `handleTranslationRequest` to ensure the target language is supported, returning a 400 error if not (`src/controllers/translationController.ts`).
* Introduced a new `getLanguages` endpoint to fetch a list of supported languages, sorted by name (`src/controllers/translationController.ts`, `src/routes/translationRoutes.ts`). [[1]](diffhunk://#diff-1e24fbb6b7573801fb1b723fed6484fc0b3561b98d55111ec053432851534bb0R98-R114) [[2]](diffhunk://#diff-ebde8a844b5b924c3d69f4a73d57b5be55a96d47dcbb250cc86d0a57a9944c92R21)

### Seeder Script:
* Added a script to seed the `supported_languages` table with predefined languages if they don't already exist (`src/seeder/seed.ts`).